### PR TITLE
Replace varmint with integer-encoding crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ readme = "README.md"
 [dependencies]
 multihash = "~0.5.0"
 multibase = "~0.6.0"
-varmint = "~0.1.2"
+integer-encoding = "~1.0.3"


### PR DESCRIPTION
Rationale: `varmint` fails to compile on non `x86_64` architectures.