### PR TITLE
fix(spelling): UnkownCodec -> UnknownCodec

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -14,7 +14,7 @@ macro_rules! build_codec_enum {
             pub fn from(raw: u64) -> Result<Codec> {
                 match raw {
                     $( $val => Ok($var), )*
-                    _ => Err(Error::UnkownCodec),
+                    _ => Err(Error::UnknownCodec),
                 }
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 /// Error types
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum Error {
-    UnkownCodec,
+    UnknownCodec,
     InputTooShort,
     ParsingError,
     InvalidCidVersion,
@@ -24,7 +24,7 @@ impl error::Error for Error {
         use self::Error::*;
 
         match *self {
-            UnkownCodec => "Unkown codec",
+            UnknownCodec => "Unknown codec",
             InputTooShort => "Input too short",
             ParsingError => "Failed to parse multihash",
             InvalidCidVersion => "Unrecognized CID version",


### PR DESCRIPTION
Pretty trivial spelling issue, but it tripped me up for longer than it should have 😅 

https://github.com/multiformats/rust-multihash and https://github.com/multiformats/rust-multibase also both have a similar misspelling. I can also submit a PR for those if you want.