### PR TITLE
Bump multihash to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-multihash = "~0.7.0"
+multihash = "~0.8.0"
 multibase = "~0.6.0"
 integer-encoding = "~1.0.3"
 


### PR DESCRIPTION
Because of semver and the fact that multihash is unfortunately exposed in the API, this also requires bumping `cid` to 0.3.